### PR TITLE
Text facsimile view

### DIFF
--- a/app/controller/window/text/TextFacsimileSplitView.js
+++ b/app/controller/window/text/TextFacsimileSplitView.js
@@ -119,7 +119,8 @@ Ext.define('EdiromOnline.controller.window.text.TextFacsimileSplitView', {
             {
                 uri: uri,
                 idPrefix: view.id + '_',
-                page: view.getActivePage()
+                page: view.getActivePage(),
+                omitLineNumbering: true
             },
             Ext.bind(function(response){
                 this.contentLoaded(view, response.responseText);

--- a/app/controller/window/text/TextFacsimileSplitView.js
+++ b/app/controller/window/text/TextFacsimileSplitView.js
@@ -84,29 +84,6 @@ Ext.define('EdiromOnline.controller.window.text.TextFacsimileSplitView', {
                 me.chaptersLoaded(chapters, view);
             }, this)
         );
-    },
-    
-    onAfterImageChanged: function(view) {
-        var uri = view.uri;
-        
-        window.doAJAXRequest('data/xql/getText.xql',
-            'GET',
-            {
-                uri: uri,
-                idPrefix: view.id + '_',
-                page: view.getActivePage()
-            },
-            Ext.bind(function(response){
-                this.contentLoaded(view, response.responseText);
-            }, this)
-        );
-    },
-    
-    contentLoaded: function(view, content) {
-
-        var me = this;
-
-        view.setContent(content);
 
         window.doAJAXRequest('data/xql/getAnnotationInfos.xql',
             'GET',
@@ -134,6 +111,32 @@ Ext.define('EdiromOnline.controller.window.text.TextFacsimileSplitView', {
         );
     },
     
+    onAfterImageChanged: function(view) {
+        var uri = view.uri;
+        
+        window.doAJAXRequest('data/xql/getText.xql',
+            'GET',
+            {
+                uri: uri,
+                idPrefix: view.id + '_',
+                page: view.getActivePage()
+            },
+            Ext.bind(function(response){
+                this.contentLoaded(view, response.responseText);
+            }, this)
+        );
+    },
+    
+    contentLoaded: function(view, content) {
+
+        var me = this;
+
+        view.setContent(content);
+        view.annotationsLoaded = false;
+
+        this.onAnnotationsVisibilityChange(view, view.annotationsVisible);        
+    },
+    
     chaptersLoaded: function(chapters, view) {
         view.setChapters(chapters);
     },
@@ -145,12 +148,12 @@ Ext.define('EdiromOnline.controller.window.text.TextFacsimileSplitView', {
     onAnnotationsVisibilityChange: function(view, visible) {
         var me = this;
 
-        if(visible && view.getActivePage() !== null)
+        if(visible && view.getActivePage() !== null) // TODO: remove check on active page?
             window.doAJAXRequest('data/xql/getAnnotationsInText.xql',
                 'GET', 
                 {
                     uri: view.uri,
-                    page: view.getActivePage()
+                    //page: view.getActivePage() // not in backend
                 },
                 Ext.bind(function(response){
                     var data = response.responseText;
@@ -167,6 +170,10 @@ Ext.define('EdiromOnline.controller.window.text.TextFacsimileSplitView', {
             view.hideAnnotations();
     },
     
+    annotationsLoaded: function(annotations, view) {
+        view.showAnnotations(annotations);
+    },
+
     onGotoChapter: function(view, pageId) {
         view.gotoPage(pageId);
     },

--- a/app/view/window/text/TextFacsimileSplitView.js
+++ b/app/view/window/text/TextFacsimileSplitView.js
@@ -156,7 +156,7 @@ Ext.define('EdiromOnline.view.window.text.TextFacsimileSplitView', {
         var me = this;
 
         if(me.annotationsLoaded) {
-            var annos = Ext.query('#' + me.id + '_textCont span.annotation');
+            var annos = Ext.query('#' + me.id + '_textCont div.annotation');
             Ext.Array.each(annos, function(anno) {
                 Ext.get(anno).show();
             });
@@ -166,7 +166,7 @@ Ext.define('EdiromOnline.view.window.text.TextFacsimileSplitView', {
 
         me.annotationsLoaded = true;
 
-        var tpl = Ext.DomHelper.createTemplate('<span id="{0}" class="annotation {1} {2} {3}" data-edirom-annot-id="{3}"></span>');
+        var tpl = Ext.DomHelper.createTemplate('<div class="annotation"><div id="{0}" class="annotIcon {1} {2} {3}" data-edirom-annot-id="{3}"></div></div>');
         
         tpl.compile();
 
@@ -183,6 +183,10 @@ Ext.define('EdiromOnline.view.window.text.TextFacsimileSplitView', {
             Ext.Array.each(plist, function(p) {
                 var targetId = p.id.substring(annoId.length + 2);
                 var target = me.el.getById(me.id + '_' + targetId);
+
+                if (!target) {
+                    return;
+                }
 
                 var shape = tpl.append(target, [me.id + '_' + p.id, categories, priority, annotation.get('id')], true);
                 
@@ -257,7 +261,7 @@ Ext.define('EdiromOnline.view.window.text.TextFacsimileSplitView', {
 
     hideAnnotations: function() {
         var me = this;
-        var annos = Ext.query('#' + me.id + '_textCont span.annotation');
+        var annos = Ext.query('#' + me.id + '_textCont div.annotation');
         Ext.Array.each(annos, function(anno) {
             var a = Ext.get(anno);
             a.setVisibilityMode(Ext.Element.DISPLAY);
@@ -281,6 +285,7 @@ Ext.define('EdiromOnline.view.window.text.TextFacsimileSplitView', {
         me.annotMenu =  Ext.create('Ext.button.Button', {
             text: getLangString('view.window.text.TextView_annotMenu'),
             indent: false,
+            cls: 'menuButton',
             menu : {
                 items: [
                     me.toggleAnnotationVisibility


### PR DESCRIPTION
Fixed problem with text facsimile view.
Each turn of the page was creating a new instance of the annotations menu.
The annotations setting were not preserved when turning the pages.
